### PR TITLE
Fix error checking on older versions of OS X

### DIFF
--- a/src/sw_name.sh
+++ b/src/sw_name.sh
@@ -44,7 +44,7 @@ format() {
 }
 
 main() {
-	[ ! -f "$license" ] && ver=$($sw_vers -v) && errlic
+	[ ! -f "$license" ] && ver=$($sw_vers -productVersion) && errlic
 
  	[ $# -eq 0 ] && {
 		println "ReleaseName:\t$(sw_name)"


### PR DESCRIPTION
On OS X 10.8 Mountain Lion `sw_vers` does not have a `-v` flag so the error handling code won't work.